### PR TITLE
Yield task.end

### DIFF
--- a/cjs-task.js
+++ b/cjs-task.js
@@ -116,10 +116,15 @@ function create_task( callback ){
   function end_task(){
     if( ! started ) throw new Error( 'CAN\'T CALL NEXT STEP BEFORE TASK STARTS' );
 
-    hook.run( 'task-end' );
-    callback.apply( callback, arguments );
+    var end_task_args = arguments;
 
-    store = log = api = null;
+    _yield( function(){
+      hook.run( 'task-end' );
+
+      callback.apply( callback, end_task_args );
+
+      store = log = api = null;
+    });
   }
 
   function create_subtask( name, handler ){

--- a/cjs-task.js
+++ b/cjs-task.js
@@ -13,7 +13,8 @@ function create_task( callback ){
       insertions = 0,
       steps_run = 0,
       steps_deleted = 0,
-      started;
+      started,
+      ended;
 
   if( ! callback ) callback = default_task_callback;
   if( typeof callback !== 'function' ) throw new Error( 'TASK CALLBACK MUST BE A FUNCTION' );
@@ -115,6 +116,7 @@ function create_task( callback ){
 
   function end_task(){
     if( ! started ) throw new Error( 'CAN\'T CALL NEXT STEP BEFORE TASK STARTS' );
+    if( ended ) return;
 
     var end_task_args = arguments;
 
@@ -125,6 +127,8 @@ function create_task( callback ){
 
       store = log = api = null;
     });
+
+    ended = true;
   }
 
   function create_subtask( name, handler ){


### PR DESCRIPTION
`task.end` is currently non-yielding, which creates situations where errors thrown in the task callback are caught by internal try/catch and the task callback is called a second time, with the error passed directly to it. 

Yielding `task.end` puts the task callback in a different callstack, breaking it out of the internal try/catch without fancy book-keeping.